### PR TITLE
Bugfixes

### DIFF
--- a/GuerrillaMailExploit.py
+++ b/GuerrillaMailExploit.py
@@ -19,9 +19,9 @@ while(True):
 
   print("Checking mailbox for the magic email...")
   email_id = None
-  for i in range(0, EMAIL_CHECK_TIMEOUT):
+  for i in range(0, EMAIL_CHECK_TIMEOUT/2):
     email_id = session.get_email_list()[0].guid
-    time.sleep(1)
+    time.sleep(2)
     if session.get_email(email_id).subject != "Confirm your email":
       continue
 

--- a/GuerrillaMailExploit.py
+++ b/GuerrillaMailExploit.py
@@ -26,7 +26,7 @@ while(True):
       continue
 
   if email_id == 1:
-    print("Couldn't find the magic email on the mailbox after " + EMAIL_CHECK_TIMEOUT + " seconds!.")
+    print("Couldn't find the magic email on the mailbox after " + str(EMAIL_CHECK_TIMEOUT) + " seconds!.")
     print("Let's try to send more invites...")
     print("")
     continue


### PR DESCRIPTION
Not converting EMAIL_CHECK_TIMEOUT into a string would result in an error,
changed to send less request because of "to many requests" error
