### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Steps to use:
 3. Download and install Requests (http://docs.python-requests.org/en/latest/)
 4. Run! (`python GuerrillaMailExploit.py`)
 
-##Additional Components
+## Additional Components
 
 ### gmailClicker - OnePlusTwo
 Click on the confirmation link in a gmail message


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
